### PR TITLE
Let's merge nerfing!

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Charcoal
 
 Adds renewable coal : charcoal.
 
-Version: 0.1.0
+Version: 0.2.0
 License: WTFPL
 
 Dependencies: default mod (found in minetest_game)
@@ -37,7 +37,7 @@ group:coal, which is good.
 
 If charcoal.separate_node = false, then charcoal IS coal, and you won't see any difference,
 except for the ability to char group:wood and group:tree - which should be any tree and wood -
-in your furnace, to gain some lumps (1 for wood, 4 for tree).
+in your furnace, to gain some lumps.
 
 charcoal.cooking_time is charcoal cooking time in seconds.
 charcoal.lump_per_tree is how many lumps you get per tree - below 4, the wood planks

--- a/README.txt
+++ b/README.txt
@@ -8,7 +8,8 @@ License: WTFPL
 
 Dependencies: default mod (found in minetest_game)
 
-Report bugs or request help on the forum topic.
+Report bugs or request help here:
+https://github.com/vlkolak/charcoal
 
 Installation
 ------------

--- a/README.txt
+++ b/README.txt
@@ -39,6 +39,10 @@ If charcoal.separate_node = false, then charcoal IS coal, and you won't see any 
 except for the ability to char group:wood and group:tree - which should be any tree and wood -
 in your furnace, to gain some lumps (1 for wood, 4 for tree).
 
+charcoal.cooking_time is charcoal cooking time in seconds.
+charcoal.lump_per_tree is how many lumps you get per tree - below 4, the wood planks
+to charcoal recipe is disabled.
+
 Recipes
 -------
 Cook wood and tree in furnace to get charcoal lump.

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,9 @@
--- registers charcoal. like coal. coal group.
+-- Charcoal mod by vlkolak - 2015
+--
+-- This mod supplies various charcoal related recipes.
+--
+-- License: WTFPL
+--
 
 print("MOD: charcoal loading")
 

--- a/init.lua
+++ b/init.lua
@@ -8,7 +8,7 @@
 print("MOD: charcoal loading")
 
 charcoal = {}
-charcoal.version = "0.1.0"
+charcoal.version = "0.2.0"
 charcoal.lump = "charcoal:charcoal_lump"
 
 charcoal.worldpath = minetest.get_worldpath()

--- a/init.lua
+++ b/init.lua
@@ -28,14 +28,18 @@ else
 end
 
 -- char some tree to get some charcoal
+if charcoal.lump_per_tree >= 4 then
+    minetest.register_craft({
+            type = "cooking",
+            cooktime = charcoal.cooking_time,
+            output = charcoal.lump .. " " .. tostring(math.floor(charcoal.lump_per_tree / 4)),
+            recipe = "group:wood",
+    })
+end
 minetest.register_craft({
         type = "cooking",
-        output = charcoal.lump,
-        recipe = "group:wood",
-})
-minetest.register_craft({
-        type = "cooking",
-        output = charcoal.lump .. " 4",
+        cooktime = charcoal.cooking_time,
+        output = charcoal.lump .. " " .. tostring(charcoal.lump_per_tree),
         recipe = "group:tree",
 })
 

--- a/settings.txt
+++ b/settings.txt
@@ -1,3 +1,5 @@
 -- charcoal as a separate node
 -- false does not "clutter" your server
 charcoal.separate_node = true
+charcoal.cooking_time = 30
+charcoal.lump_per_tree = 2


### PR DESCRIPTION
OK, now charcoal mod is nerfable through
charcoal.cooking_time
charcoal.lump_per_tree

Cooking time is configurable. It is supposed to be quite long - the idea would be to char tree into coal, not burn it to the ground.
Lump(s) per tree is also configurable - 4 per tree is, in fact, a lot.
It may seems too much, so it is a setting, for the user to decide what is too much.
